### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -17,7 +17,7 @@ jobs:
 
             ## Publishes our image to Docker Hub 😎
             - name: Publish to Registry
-              uses: elgohr/Publish-Docker-Github-Action@master
+              uses: elgohr/Publish-Docker-Github-Action@v5
               with:
                   ## the name of our image
                   name: danish5007/termoogle


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore